### PR TITLE
Return all events for 2022 meetings

### DIFF
--- a/python/cdp_missoula_backend/scraper.py
+++ b/python/cdp_missoula_backend/scraper.py
@@ -228,19 +228,7 @@ def get_events(
     print(events)
     print(len(events))
 
-    hardcoded_mtg = EventIngestionModel(
-        body=Body(name="Affordable Housing Resident Oversight Committee"),
-        sessions=[
-            Session(
-                video_uri="https://video.isilive.ca/missoula/Encoder1_AHROC_2022"
-                "-03-09-07-51.mp4",
-                session_datetime=datetime(2022, 3, 9, 18),
-                session_index=0,
-            ),
-        ],
-    )
-
-    return [hardcoded_mtg]
+    return events
 
 
 def print_duration_info(meetings_info):


### PR DESCRIPTION
After verifying the output of running the scraper in CI, this PR returns an array of the actual events for all 2022 Missoula public meetings.

🤞 