### PR TITLE
admin/upgrade-to-new-cron-and-event-lookback-params

### DIFF
--- a/.github/workflows/event-gather-pipeline.yml
+++ b/.github/workflows/event-gather-pipeline.yml
@@ -7,9 +7,7 @@ on:
   schedule:
     # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
     # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # Run every day at 0,6,12,18:26:00 UTC
-    # We offset from the hour and half hour to go easy on the servers :)
-    - cron: '26 0,6,12,18 * * *'
+    - cron: '7 9,21 * * *'
   workflow_dispatch:
     inputs:
       from:

--- a/.github/workflows/event-index-pipeline.yml
+++ b/.github/workflows/event-index-pipeline.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Install Python Dependencies
       run: |
         cd python/
-        pip install .
+        pip install .[pipeline]
     
     # Upload Index Chunk
     - name: Process Upload

--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -11,3 +11,5 @@ default_context:
     hosting_github_url: "https://github.com/OpenMontana/missoula-council-data-project"
     hosting_web_app_address: "https://OpenMontana.github.io/missoula-council-data-project"
     firestore_region: "us-central"
+    event_gather_timedelta_lookback_days: 2
+    event_gather_cron: "7 9,21 * * *"


### PR DESCRIPTION
Hey @smai-f 

Another new cookiecutter update. Who knew infrastructure configuration would require semi constant maintenance 😂

This just makes the "default event gather lookback days" and the "event gather cron" both cookiecutter params. I also lowered how often the scraper runs with the new cron.

The goal of this work was to make it easier to set up new instances and specifically for the instances covered by legistar to provide random CRON strings to all of them so that we don't overload legistar servers by running them all at the same time. Less of a concern for this instance but good to stay up-to-date.

Merge whenever you want!