### PR TITLE
Fix webdriver issue in scraper

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -24,12 +24,12 @@ jobs:
       run: |
         cd python/
         pip install .[test]
-    - name: Lint and Format Python
+
+    - name: Ruff Check
       run: |
         cd python/
-        flake8 cdp_missoula_backend --count --verbose --show-source --statistics
-        black --check cdp_missoula_backend
-  
+        ruff check cdp_missoula_backend
+
   build-web:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/event-gather-pipeline.yml
+++ b/.github/workflows/event-gather-pipeline.yml
@@ -33,7 +33,12 @@ jobs:
     - name: Install Packages
       run: |
         sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt -m -f install ffmpeg libu2f-udev
+
+    - name: Install Google Chrome
+      run: |
+        wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        sudo dpkg -i google-chrome-stable_current_amd64.deb
 
     - name: Install Python Dependencies
       run: |
@@ -58,7 +63,7 @@ jobs:
       run: |
         cd python/
         run_cdp_event_gather event-gather-config.json --parallel
-    
+
     - name: Gather and Process Requested Events - Manual
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |

--- a/python/cdp_missoula_backend/scraper.py
+++ b/python/cdp_missoula_backend/scraper.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from datetime import timedelta
 from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -135,7 +136,9 @@ def get_scraped_data(
     options.add_argument("--incognito")
     options.add_argument("--headless")
 
-    driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
+    driver = webdriver.Chrome(
+        service=ChromeService(ChromeDriverManager().install()), options=options
+    )
 
     msla_url = "https://pub-missoula.escribemeetings.com/"
     driver.get(msla_url)

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,10 +1,2 @@
 [bdist_wheel]
 universal = 1
-
-[flake8]
-ignore = 
-	E203
-	E402
-	W291
-	W503
-max-line-length = 88

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,9 +12,7 @@ requirements = [
 ]
 
 test_requirements = [
-    "black>=19.10b0",
-    "flake8>=3.8.3",
-    "flake8-debugger>=3.2.1",
+    "ruff==0.4.4"
 ]
 
 dev_requirements = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,8 +7,8 @@ from setuptools import find_packages, setup
 
 requirements = [
     "cdp-backend[pipeline]==3.2.3",
-    "selenium",
-    "webdriver_manager",
+    "selenium==4.21.0",
+    "webdriver_manager==4.0.1",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Fixes issues with the scraper webdriver

- Pin selenium and webdriver_manager dependencies, we don't want these to change.
- Inject a ChromeService to webdriver.Chrome instead of the driver path. (This changed at some point in selenium API, hence the pinning to prevent it from happening again without an explicit upgrade.)
- Install Chrome in the workflow jobs so that the driver can find an instance of Chrome to use.
- Replace black/flake8 with ruff

TODO

~- [ ] Test locally with act~ Not able to test locally since I don't have `GOOGLE_CREDENTIALS` created by @smai-f when this project was initialized. Nor do I have access to the project in google cloud.

I'm reasonably confident that this fix will work based on manual testing and it is already broken as-is so it can't break _more_.